### PR TITLE
Just A few Changes

### DIFF
--- a/2.5_Audit_List.sh
+++ b/2.5_Audit_List.sh
@@ -3,4 +3,4 @@
 # Security Reporting - List Risks
 
 auditfile=/Library/Application\ Support/SecurityScoring/org_audit
-echo "<result>`cat \"$auditfile\"`</result>"
+echo "<result>$(cat "$auditfile")</result>"

--- a/2.6_Audit_Count.sh
+++ b/2.6_Audit_Count.sh
@@ -3,4 +3,5 @@
 # Security Reporting - Count Risks
 
 auditfile=/Library/Application\ Support/SecurityScoring/org_audit
-echo "<result>`cat \"$auditfile\" | grep "*" | wc -l`</result>"
+reportcount=$(cat "$auditfile" | grep "*" | wc -l | tr -d '[:space:]')
+echo "<result>$(cat "$auditfile" | grep "*" | wc -l | tr -d '[:space:]')</result>"

--- a/2.6_Audit_Count.sh
+++ b/2.6_Audit_Count.sh
@@ -3,5 +3,4 @@
 # Security Reporting - Count Risks
 
 auditfile=/Library/Application\ Support/SecurityScoring/org_audit
-reportcount=$(cat "$auditfile" | grep "*" | wc -l | tr -d '[:space:]')
 echo "<result>$(cat "$auditfile" | grep "*" | wc -l | tr -d '[:space:]')</result>"


### PR DESCRIPTION
The Main Change was replacing the Backtick "`" with "$( )".
Otherwise I made attempts to have less calls to the "/usr/sbin/system_profiler".
Why call it on three unique occasions where one direct call will do?
I'm still working on a few things.

Next big change will be a function that looks up the plist value instead of direct calls through defaults and plistbuddy as there is nothing that accounts for missing values or files in that code.